### PR TITLE
fix: compute domain name length correctly

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -121,9 +121,8 @@ pub(crate) fn check_byte_sequence(bytes: &[u8]) -> Result<(),Error>
         _ => return Err(Error::TrailingNulCharMissing)
     }
 
-    // check against 256 since we have the trailing char and the first label length to consider
     #[cfg(feature="domain-name-length-limited-to-255")]
-    if bytes.len() > 256 {
+    if bytes.len() > 255 {
         return Err(Error::TooLongDomainName)
     }
     // if unlimited, then the radix trie limits it to u32::MAX

--- a/src/fqdn.rs
+++ b/src/fqdn.rs
@@ -142,12 +142,6 @@ impl FromStr for FQDN
 
     fn from_str(s: &str) -> Result<Self, Self::Err>
     {
-        // check against 255 since we expected the trailing dot
-        #[cfg(feature="domain-name-length-limited-to-255")]
-        if s.len() > 255 {
-            return Err(Error::TooLongDomainName)
-        }
-
         // check the trailing dot and remove it
         // (the empty FQDN '.' is also managed here)
         let s = s.as_bytes();
@@ -172,6 +166,12 @@ impl FromStr for FQDN
                 s // no trailing dot to remove
             }
         };
+
+        // check against 253 since we have the trailing char and the first label length to consider
+        #[cfg(feature="domain-name-length-limited-to-255")]
+        if toparse.len() > 253 {
+            return Err(Error::TooLongDomainName);
+        }
 
         // now, check each FQDN subpart and concatenate them
         toparse

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,29 @@ mod tests {
         assert_eq!("github..com.".parse::<FQDN>(), Err(fqdn::Error::EmptyLabel));
         assert_eq!(".github.com.".parse::<FQDN>(), Err(fqdn::Error::EmptyLabel));
         assert_eq!("git@ub.com.".parse::<FQDN>(), Err(fqdn::Error::InvalidLabelChar));
+
+        const LENGTH_256: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.";
+        const LENGTH_255: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.";
+
+        #[cfg(feature="domain-name-length-limited-to-255")]
+        assert_eq!(LENGTH_256.parse::<FQDN>(), Err(fqdn::Error::TooLongDomainName));
+
+        #[cfg(not(feature="domain-name-length-limited-to-255"))]
+        assert!(LENGTH_256.parse::<FQDN>().is_ok());
+
+        assert!(LENGTH_255.parse::<FQDN>().is_ok());
+
+        #[cfg(not(feature="domain-name-should-have-trailing-dot"))]
+        {
+            #[cfg(feature="domain-name-length-limited-to-255")]
+            assert_eq!(LENGTH_256[..LENGTH_256.len() - 1].parse::<FQDN>(), Err(fqdn::Error::TooLongDomainName));
+
+            #[cfg(not(feature="domain-name-length-limited-to-255"))]
+            assert!(LENGTH_256[..LENGTH_256.len() - 1].parse::<FQDN>().is_ok());
+
+            assert!(LENGTH_255[..LENGTH_255.len() - 1].parse::<FQDN>().is_ok());
+        }
+
     }
 
     #[test]
@@ -125,6 +148,17 @@ mod tests {
             assert_eq!(Fqdn::from_bytes(b"\x05-yeah\x0512345\x03com\x00"), Err(fqdn::Error::LabelCannotStartWithHyphen));
             assert_eq!(Fqdn::from_bytes(b"\x05yeah-\x0512345\x03com\x00"), Err(fqdn::Error::LabelCannotEndWithHyphen));
         }
+
+        const LENGTH_256: &[u8; 256] = b"\x3faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\x3faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\x3faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\x3eaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\x00";
+        const LENGTH_255: &[u8; 255] = b"\x3faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\x3faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\x3faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\x3daaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\x00";
+
+        #[cfg(feature="domain-name-length-limited-to-255")]
+        assert_eq!(Fqdn::from_bytes(LENGTH_256), Err(fqdn::Error::TooLongDomainName));
+
+        #[cfg(not(feature="domain-name-length-limited-to-255"))]
+        assert!(Fqdn::from_bytes(LENGTH_256).is_ok());
+
+        assert!(Fqdn::from_bytes(LENGTH_255).is_ok());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,6 @@ mod tests {
 
             assert!(LENGTH_255[..LENGTH_255.len() - 1].parse::<FQDN>().is_ok());
         }
-
     }
 
     #[test]


### PR DESCRIPTION
According to [RFC 1035 section 3.1](https://www.rfc-editor.org/rfc/rfc1035#section-3.1), the length of a domain name is the total number of label octets and label length octets it contains, including the null label at the end. This PR fixes the `domain-name-length-limited-to-255` feature to conform to the RFC.
